### PR TITLE
Fix background cell first element bug

### DIFF
--- a/components/BackgroundCells.tsx
+++ b/components/BackgroundCells.tsx
@@ -38,7 +38,7 @@ export default function BackgroundCells() {
                     value: bc.value
                   })
                 }
-                defaultChecked={backgroundCell.value === bc.value}
+                checked={backgroundCell.value === bc.value}
               />
               <div
                 className={classnames([


### PR DESCRIPTION
Arreglé un bug con la selección del fondo de los cartones. 
Este bug ocurre cuando abris o refrescas la página del juego con la vista de los cartones, teniendo elegido cualquier color/imagen de fondo menos el primero y queres cambiar de color al primero ->amarillito. Al elegir el primer color, no se selecciona esa opción y tampoco cambia de color los cartones. Pero eligiendo cualquier otra opción sí lo hace.
Hay un problema cuando queres elegir el primer radio input, que no dispara el "onChange" del mismo, pero si cambia el checked del input en el DOM. Cambiando defaultChecked a checked se soluciona ese problema.
