### PR TITLE
Heading component replacing html header elements

### DIFF
--- a/components/BackgroundCells.tsx
+++ b/components/BackgroundCells.tsx
@@ -5,6 +5,7 @@ import { COLORS } from '~/components/EmptyCell'
 import { BackgroundCellContext } from '~/contexts/BackgroundCellContext'
 import { BACKGROUND_CELL_VALUES } from '~/utils/constants'
 import InputText from './InputText'
+import Heading from '~/components/Heading'
 
 export default function BackgroundCells() {
   const { backgroundCell, setBackgroundCell } = useContext(
@@ -13,9 +14,7 @@ export default function BackgroundCells() {
   const { t } = useTranslation()
   return (
     <Fragment>
-      <h2 className="font-medium mb-4 text-center text-lg md:text-xl">
-        {t('jugar:empty-cells.title')}
-      </h2>
+      <Heading type="h2">{t('jugar:empty-cells.title')}</Heading>
       <div className="flex flex-wrap">
         {BACKGROUND_CELL_VALUES.map(({ key, type, value }, i) => {
           const firstOrDefault = Array.isArray(value) ? value[0] : value

--- a/components/CreateRoom.tsx
+++ b/components/CreateRoom.tsx
@@ -8,6 +8,7 @@ import isObjectFulfilled from '~/utils/isObjectFulfilled'
 import Button from './Button'
 import InputText from './InputText'
 import Message, { MessageType } from './Message'
+import Heading from '~/components/Heading'
 
 export default function CreateRoom() {
   const { t } = useTranslation()
@@ -69,9 +70,9 @@ export default function CreateRoom() {
 
   return (
     <Fragment>
-      <h2 className="font-medium text-lg md:text-xl text-center uppercase">
-        {t('index:create-room.title')}
-      </h2>
+      <Heading type="h2">
+        <span className="uppercase">{t('index:create-room.title')}</span>
+      </Heading>
       <form onSubmit={onSubmit}>
         <InputText
           id="name"

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -4,6 +4,7 @@ import useTranslation from 'next-translate/useTranslation'
 import React from 'react'
 import { allLanguages } from '~/i18n.json'
 import Select from './Select'
+import Heading from '~/components/Heading'
 
 export default function Header() {
   const { t, lang } = useTranslation()
@@ -37,14 +38,14 @@ export default function Header() {
     <header className="bg-white px-4 py-2 shadow">
       <div className="max-w-4xl mx-auto">
         <div className="flex items-center justify-between">
-          <h1 className="font-medium text-xl md:text-2xl">
+          <Heading type="h1">
             <Link href="/">
               {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
               <a className="focus:outline-none focus:shadow-outline">
                 Coronabingo
               </a>
             </Link>
-          </h1>
+          </Heading>
           <Select
             id="language"
             onChange={onLanguageChange}

--- a/components/Heading.tsx
+++ b/components/Heading.tsx
@@ -1,0 +1,31 @@
+import React, { ReactNode } from 'react'
+import classnames from 'classnames'
+
+const HEADER_STYLES = {
+  h1: ['text-xl', 'md:text-2xl'],
+  h2: ['text-lg', 'md:text-xl', 'mb-4'],
+  h3: [],
+  h4: [],
+}
+
+interface Props {
+  children: ReactNode
+  type?: 'h1' | 'h2' | 'h3' | 'h4'
+  textCenter?: boolean
+}
+
+export default function Heading({
+  children,
+  type = 'h1',
+  textCenter = true,
+}: Props) {
+  const Type = type
+
+  const className = classnames([
+    'font-medium',
+    textCenter ? 'text-center' : null,
+    ...HEADER_STYLES[type],
+  ])
+
+  return <Type className={className}>{children}</Type>
+}

--- a/components/Pato.tsx
+++ b/components/Pato.tsx
@@ -11,6 +11,7 @@ import { FiPlayCircle } from 'react-icons/fi'
 import { EasterEggContext } from '~/contexts/EasterEggContext'
 import { SOUNDS, SOUNDS_EXTRAS } from '~/utils/constants'
 import Button from './Button'
+import Heading from '~/components/Heading'
 
 const emojis: { [key: string]: ReactNode } = {
   ar: (
@@ -54,7 +55,7 @@ export default function Pato({ activeSound, onClick }: Props) {
 
   return (
     <Fragment>
-      <h2 className="font-medium mb-4 text-center text-lg md:text-xl">
+      <Heading type="h2">
         <span
           onClick={tricks}
           role="button"
@@ -64,7 +65,7 @@ export default function Pato({ activeSound, onClick }: Props) {
         >
           {t('jugar:sounds')}
         </span>
-      </h2>
+      </Heading>
       <div className="border-gray-300 border-t-2 -mx-4">
         {sounds.map(({ language, name, url }, index) => (
           <div

--- a/pages_/room/[roomId].tsx
+++ b/pages_/room/[roomId].tsx
@@ -13,6 +13,7 @@ import { Player } from '~/components/Players'
 import useRoom from '~/hooks/useRoom'
 import useRoomPlayers from '~/hooks/useRoomPlayers'
 import scrollToTop from '~/utils/scrollToTop'
+import Heading from '~/components/Heading'
 
 export default function Sala() {
   const [room] = useRoom()
@@ -26,9 +27,7 @@ export default function Sala() {
       <Container>
         <Box>
           <div className="mb-8">
-            <h2 className="font-medium text-center text-lg md:text-xl">
-              {t('sala:title')}
-            </h2>
+            <Heading type="h2">{t('sala:title')}</Heading>
           </div>
           <div className="mb-8">
             <img
@@ -76,9 +75,9 @@ export default function Sala() {
             </div>
           ) : (
             <div className="mt-8">
-              <h3 className="font-medium">
+              <Heading type="h3" textCenter={false}>
                 {t('sala:people', { count: players.length })}
-              </h3>
+              </Heading>
               <div className="italic -mt-6 text-gray-600 text-xs md:text-sm">
                 <p className="my-8">{t('sala:list-description')}</p>
               </div>

--- a/pages_/room/[roomId]/[playerId].tsx
+++ b/pages_/room/[roomId]/[playerId].tsx
@@ -20,6 +20,7 @@ import { EasterEggContextProvider } from '~/contexts/EasterEggContext'
 import useRoom from '~/hooks/useRoom'
 import useRoomPlayers from '~/hooks/useRoomPlayers'
 import scrollToTop from '~/utils/scrollToTop'
+import Heading from '~/components/Heading'
 
 export default function Jugar() {
   const [room] = useRoom()
@@ -89,29 +90,25 @@ export default function Jugar() {
     <EasterEggContextProvider>
       <BackgroundCellContextProvider playerId={player.id}>
         <Layout>
-          <h2 className="font-medium text-center text-lg md:text-xl">
+          <Heading type="h2">
             {t('jugar:title', {
               playerName: player?.name || '',
               roomName: room.name || '',
             })}
-          </h2>
+          </Heading>
           <div className="max-w-6xl mx-auto">
             <div className="lg:flex mt-4">
               {room && (
                 <div className="lg:w-1/3">
                   <Box>
-                    <h2 className="font-medium mb-4 text-center text-lg md:text-xl">
-                      {t('jugar:last-numbers')}
-                    </h2>
+                    <Heading type="h2">{t('jugar:last-numbers')}</Heading>
                     <LastNumbers
                       selectedNumbers={room?.selectedNumbers || []}
                     />
                   </Box>
                   <div className="hidden lg:block mt-4">
                     <Box>
-                      <h2 className="font-medium mb-4 text-center text-lg md:text-xl">
-                        {t('common:bingo-spinner')}
-                      </h2>
+                      <Heading type="h2">{t('common:bingo-spinner')}</Heading>
                       <div className="mt-4">
                         <SelectedNumbers
                           isAdmin={isAdmin}
@@ -143,9 +140,7 @@ export default function Jugar() {
             </div>
             <div className="lg:hidden mt-4">
               <Box>
-                <h2 className="font-medium mb-4 text-center text-lg md:text-xl">
-                  {t('common:bingo-spinner')}
-                </h2>
+                <Heading type="h2">{t('common:bingo-spinner')}</Heading>
                 <div className="mt-4">
                   <SelectedNumbers
                     isAdmin={isAdmin}

--- a/pages_/room/[roomId]/admin.tsx
+++ b/pages_/room/[roomId]/admin.tsx
@@ -17,6 +17,7 @@ import useRoomPlayers from '~/hooks/useRoomPlayers'
 import Field from '~/interfaces/Field'
 import db from '~/utils/firebase'
 import scrollToTop from '~/utils/scrollToTop'
+import Heading from '~/components/Heading'
 
 export default function Admin() {
   const { t } = useTranslation()
@@ -79,9 +80,7 @@ export default function Admin() {
     <Layout>
       <Container>
         <Box>
-          <h2 className="font-medium text-center text-lg md:text-xl">
-            {t('admin:title')}
-          </h2>
+          <Heading type="h2">{t('admin:title')}</Heading>
           {!room?.id && (
             <div className="mt-8">
               <Message type="information">{t('admin:loading')}</Message>

--- a/pages_/stats.tsx
+++ b/pages_/stats.tsx
@@ -4,6 +4,7 @@ import Box from '~/components/Box'
 import Container from '~/components/Container'
 import Message from '~/components/Message'
 import db from '~/utils/firebase'
+import Heading from '~/components/Heading'
 
 interface Stats {
   roomsByDay: {
@@ -147,9 +148,7 @@ export default function Index() {
     <main className="bg-gray-200 leading-normal min-h-screen px-4 py-8 text-gray-900 text-sm md:text-base">
       <Container size="large">
         <Box>
-          <h1 className="font-medium text-center text-lg md:text-xl">
-            Estadísticas
-          </h1>
+          <Heading type="h1">Estadísticas</Heading>
           {!stats && (
             <div className="mt-8">
               <Message type="information">Obteniendo información...</Message>
@@ -158,9 +157,9 @@ export default function Index() {
           {stats && (
             <Fragment>
               <div className="mt-8">
-                <h2 className="font-medium text-md md:text-lg">
+                <Heading type="h2" textCenter={false}>
                   Sobre las salas
-                </h2>
+                </Heading>
               </div>
               <div className="border-gray-300 border-l-2 border-r-2 border-t-2 flex flex-col mt-8 rounded">
                 {renderRow(
@@ -220,9 +219,9 @@ export default function Index() {
                 )}
               </div>
               <div className="mt-8">
-                <h2 className="font-medium text-md md:text-lg">
+                <Heading type="h2" textCenter={false}>
                   Los 10 días donde se configuraron más salas
-                </h2>
+                </Heading>
               </div>
               <div className="border-gray-300 border-l-2 border-r-2 border-t-2 flex flex-col mt-8 rounded">
                 {stats.sortedRoomsByDay.map(({ date, value }, i) => (


### PR DESCRIPTION
Para cada elemento del header le asocie una serie de estilos distintos según lo que ya estaba especificado en el código.
Al unificar criterios en la página de estadísticas los tamaños de las elementos se ven más grandes, pero se priorizó la consistencia con los demás casos.
En cuanto al centrado del texto cree una prop para especificarlo, ya que encontré casos donde se usa el mismo y otros que no.
