### PR TITLE
Simplify ball colors in the Lastnumbers component.

### DIFF
--- a/components/Ball.tsx
+++ b/components/Ball.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 
 interface Props {
   animate?: boolean
-  color: string
+  color: 'yellow' | 'gray'
   number: number
   size?: number
 }
@@ -19,10 +19,8 @@ export default function Ball({
       <div
         className={classnames([
           'ball',
-          color === 'blue' && 'bg-blue-600',
-          color === 'green' && 'bg-green-600',
-          color === 'red' && 'bg-red-600',
-          color === 'yellow' && 'bg-yellow-600',
+          color === 'yellow' && 'bg-yellow-500',
+          color === 'gray' && 'bg-gray-400',
         ])}
         style={{
           height: `${size}px`,

--- a/components/LastNumbers.tsx
+++ b/components/LastNumbers.tsx
@@ -1,7 +1,7 @@
 import classnames from 'classnames'
 import useTranslation from 'next-translate/useTranslation'
 import React, { Fragment } from 'react'
-import { BOARD_NUMBER_COLOR, DREAMS_EMOJIS } from '~/utils/constants'
+import { DREAMS_EMOJIS } from '~/utils/constants'
 import Anchor from './Anchor'
 import Ball from './Ball'
 
@@ -20,25 +20,16 @@ export default function LastNumbers({ selectedNumbers }: Props) {
         <Fragment>
           <div className="flex items-center overflow-hidden">
             <div style={{ flex: '0 0 85px' }}>
-              <Ball
-                animate
-                color={BOARD_NUMBER_COLOR[last - 1]}
-                number={last}
-                size={75}
-              />
+              <Ball animate color="yellow" number={last} size={75} />
             </div>
             <div className="flex flex-auto overflow-x-scroll">
               {rest.map(n => (
                 <div
-                  className="opacity-50"
+                  className="opacity-75"
                   key={n}
                   style={{ flex: '0 0 65px' }}
                 >
-                  <Ball
-                    color={BOARD_NUMBER_COLOR[n - 1]}
-                    number={n}
-                    size={55}
-                  />
+                  <Ball color="gray" number={n} size={55} />
                 </div>
               ))}
             </div>

--- a/utils/constants.tsx
+++ b/utils/constants.tsx
@@ -1,5 +1,3 @@
-const knuthShuffle = require('knuth-shuffle').knuthShuffle
-
 export const BACKGROUND_CELL_VALUES = [
   { key: 'jugar:backgrounds.yellow', type: 'color', value: 'yellow' },
   { key: 'jugar:backgrounds.blue', type: 'color', value: 'blue' },
@@ -61,11 +59,9 @@ export const BACKGROUND_CELL_VALUES = [
     ],
   },
 ]
-export const BALL_COLORS = ['blue', 'green', 'red', 'yellow']
+
 export const BOARD_NUMBERS = [...Array(90).keys()].map(n => n + 1)
-export const BOARD_NUMBER_COLOR = BOARD_NUMBERS.map(
-  () => knuthShuffle(BALL_COLORS.slice(0))[0],
-)
+
 export const DREAMS_EMOJIS = [
   'em-sweat_drops',
   'em-boy',


### PR DESCRIPTION
Removí el código que se encontraba en Constants para la elección de colores de las Balls en LastNumbers. Determiné los colores en el archivo LastNumbers, y modifiqué la opacidad de los números que ya salieron para que se vea un poco más nítidos (de 50 a 75 de opacidad). 
En el archivo Ball a la vez simplifiqué la lista de colores a solos los dos que se van a utilizar e hice más estricto el tipo de color que el componente acepta.