### PR TITLE
Fix issue on iOS devices

### DIFF
--- a/hooks/useIOSDetection.tsx
+++ b/hooks/useIOSDetection.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from 'react'
+
+export default function useIOSDetection() {
+  const [isIOS, setIsIOS] = useState(false)
+
+  useEffect(() => {
+    const iDevices = [
+      'iPad Simulator',
+      'iPhone Simulator',
+      'iPod Simulator',
+      'iPad',
+      'iPhone',
+      'iPod',
+    ]
+
+    if (!!navigator.platform) {
+      while (iDevices.length) {
+        if (navigator.platform === iDevices.pop()) {
+          setIsIOS(true)
+
+          return
+        }
+      }
+    }
+
+    setIsIOS(false)
+  }, [])
+
+  return isIOS
+}


### PR DESCRIPTION
Probé muchas cosas y esto fue lo más potable que pude hacer: en dispositivos iOS guardar cada cambio en los cartones 🤷🏻‍♂️

Lo cierto es que `onbeforeunload` en esos dispositivos no se triggerea y no podemos hacer nada al respecto. Mucha gente recomienda usar Page Visibility API pero no es lo mismo (lo probé), porque el caso principal (ejecutar algo cuando el tab se cierra o refresca) no lo soluciona

Mañana vemos con Angie bien la cuota de uso de estos devices pero digamos que prefiero "pagar el costo" de salvar cada cambio en firebase a cambio de que todo ande bien :)