### PR TITLE
El bolillero online se habilita por defecto al crear una sala

### DIFF
--- a/locales/en/admin.json
+++ b/locales/en/admin.json
@@ -7,7 +7,7 @@
   "field-link-hint": "Share this link with the people in the videocall.",
   "field-link": "Link to the room",
   "field-videocall": "Link to the videocall",
-  "field-bingo-spinner-hint": "If you need an online bingo spinner check this option.",
+  "field-bingo-spinner-hint": "If you have a bingo spinner and want to use it, uncheck this option.",
   "field-bingo-spinner": "Use online bingo spinner",
   "field-submit": "Play",
   "players": {

--- a/locales/es/admin.json
+++ b/locales/es/admin.json
@@ -7,7 +7,7 @@
   "field-link-hint": "Compartí este link a las personas de la videollamada.",
   "field-link": "Link a la sala",
   "field-videocall": "Link a la videollamada",
-  "field-bingo-spinner-hint": "Si tenés un bolillero y querés usarlo no tildes esta opción. De lo contrario, tildala para tener un bolillero durante el juego.",
+  "field-bingo-spinner-hint": "Si tenés un bolillero y querés usarlo no tildes esta opción.",
   "field-bingo-spinner": "Usar bolillero online",
   "field-submit": "Jugar",
   "players": {

--- a/pages_/room/[roomId]/admin.tsx
+++ b/pages_/room/[roomId]/admin.tsx
@@ -126,7 +126,7 @@ export default function Admin() {
                   onChange={value =>
                     onFieldChange([{ key: 'bingoSpinner', value }])
                   }
-                  value={room.bingoSpinner || false}
+                  value={room.bingoSpinner || true}
                 />
               </div>
               <div className="mt-8">


### PR DESCRIPTION
Dado que más del 90% de las salas que se crearon usaron el bolillero online creo que está bueno habilitarlo por defecto 🙂

PD: No es una idea mía jaja pero me pareció genial